### PR TITLE
fix: prevent mutating values twice

### DIFF
--- a/src/NullableFields.php
+++ b/src/NullableFields.php
@@ -26,7 +26,7 @@ trait NullableFields
     {
         static::saving(function ($model) {
             foreach ($model->nullableFromArray($model->getAttributes()) as $column => $value) {
-                $model->setAttribute($column, $model->nullIfEmpty($value));
+                $model->attributes[$column] = $model->nullIfEmpty($value);
             }
         });
     }


### PR DESCRIPTION
By using array notation to set an attribute instead of using the setAttribute method on the model, we prevent invoking any mutators that are set up for fields marked as nullable.
